### PR TITLE
Fix Linux .tmp file leftover

### DIFF
--- a/compile.c
+++ b/compile.c
@@ -244,6 +244,11 @@ int main(int argc, char **argv)
 					}
 					if (mcpp_lib_main(foo.file, newfile, buf.name, buf.name, defMacro, includeDir)) {
 						parseOutput("*** An error occured during preprocessing of %s ***\n", buf.name);
+#ifndef WIN32
+						if (strlen(tmp_file_name) > 0) {
+							remove(tmp_file_name);
+						}
+#endif
 						return 1;
 					}
 					fclose(foo.file);

--- a/test/utils.bash
+++ b/test/utils.bash
@@ -175,6 +175,10 @@ run_tests() {
         set -e
         TEST_FAILED_FILES="$TEST_FAILED_FILES$DIR/$FNAME=STDOUT$NEW_LINE"
         TESTS_FAILED_COUNT=$((TESTS_FAILED_COUNT + 1))
+      elif ls *.tmp 1> /dev/null 2>&1; then
+        echo "  > FAIL: Temporary files found, please check the test"
+        TEST_FAILED_FILES="$TEST_FAILED_FILES$DIR/$FNAME=TMPFILES$NEW_LINE"
+        TESTS_FAILED_COUNT=$((TESTS_FAILED_COUNT + 1))
       else
         TESTS_SUCCESS_COUNT=$((TESTS_SUCCESS_COUNT + 1))
         echo "  > OK"


### PR DESCRIPTION
This PR fixes `*.tmp` leftovers on Linux system when compilation fails on pre-processing stage