### PR TITLE
Use NODERAWFS for wasm builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,7 +245,7 @@ jobs:
       - name: Upload .wasm artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: wasm-emscripten-node-nodefs
+          name: wasm-emscripten-node-noderawfs
           path: build/bin/**
 
   build_linux:
@@ -315,8 +315,8 @@ jobs:
 
           cd artifacts
 
-          mv wasm-emscripten-node-nodefs package
-          tar -czf wasm-emscripten-node-nodefs.tar.gz package
+          mv wasm-emscripten-node-noderawfs package
+          tar -czf wasm-emscripten-node-noderawfs.tar.gz package
           rm -rf package
 
           ls -laR

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,24 +68,6 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
 
   target_link_options(${EXECUTABLE_NAME} PRIVATE "-sSTACK_SIZE=2048000")
 
-  # Next commands replaces import.meta.url with __filename in sslc.mjs
-  # This is done to support importing in VScode-BGforge-MLS
-  set(patch_script "${CMAKE_BINARY_DIR}/patch_sslc.cmake")
-  file(WRITE "${patch_script}" "
-      if(EXISTS \"${CMAKE_CURRENT_BINARY_DIR}/bin/sslc.mjs\")
-          file(READ \"${CMAKE_CURRENT_BINARY_DIR}/bin/sslc.mjs\" file_content)
-          string(REPLACE \"import.meta.url\" \"__filename\" file_content \"\${file_content}\")
-          file(WRITE \"${CMAKE_CURRENT_BINARY_DIR}/bin/sslc.__filename.mjs\" \"\${file_content}\")
-          message(STATUS \"Patched sslc.mjs\")
-      else()
-          message(FATAL_ERROR \"sslc.mjs does not exist!\")
-      endif()
-  ")
-  add_custom_command(TARGET ${EXECUTABLE_NAME} POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -P "${patch_script}"
-    COMMENT "Applying patch to sslc.mjs"
-  )
-
   set(PACKAGE_JSON_CONTENT [[
   {
     "name": "sslc-emscripten-noderawfs",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
   target_link_options(${EXECUTABLE_NAME} PRIVATE "-sNO_DISABLE_EXCEPTION_CATCHING")
 
   target_link_options( ${EXECUTABLE_NAME} PRIVATE "-lnodefs.js" )
-  # target_link_options(${EXECUTABLE_NAME} PRIVATE "-sNODERAWFS")
+  target_link_options(${EXECUTABLE_NAME} PRIVATE "-sNODERAWFS")
 
   # Disabled because of emscipten bug
   # target_link_options( ${EXECUTABLE_NAME} PRIVATE "-sCASE_INSENSITIVE_FS" )
@@ -88,7 +88,7 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Emscripten")
 
   set(PACKAGE_JSON_CONTENT [[
   {
-    "name": "sslc-emscripten-nodefs",
+    "name": "sslc-emscripten-noderawfs",
     "version": "1.0.0",
     "description": "",
     "main": "sslc.mjs",

--- a/compiler.mjs
+++ b/compiler.mjs
@@ -34,26 +34,9 @@ async function compile(sslcArgs, wasmBinary, cwd) {
         : {}),
     });
 
-    instance.FS.mkdir("/host");
-
     const cwdPath = path.parse(cwd || process.cwd());
 
-    // console.info("DEBUG cwd", cwd);
-
-    instance.FS.mount(
-      // Using NODEFS instead of NODERAWFS because
-      // NODERAWFS caused errors when the same module
-      // runs the second time
-      instance.NODEFS,
-      {
-        root: cwdPath.root,
-      },
-      "/host"
-    );
-
-    // console.info("DEBUG after mount");
-
-    instance.FS.chdir(path.join("host", cwdPath.dir, cwdPath.name));
+    instance.FS.chdir(path.join(cwdPath.dir, cwdPath.name));
 
     // console.info("DEBUG after chdir");
 
@@ -62,7 +45,6 @@ async function compile(sslcArgs, wasmBinary, cwd) {
     // console.info("DEBUG after call");
 
     instance.FS.chdir("/");
-    instance.FS.unmount("/host");
 
     return {
       returnCode,

--- a/test/test_on_fallout2_rpu_setup.bash
+++ b/test/test_on_fallout2_rpu_setup.bash
@@ -65,9 +65,12 @@ fi
 
 cd Fallout2_Restoration_Project/scripts_src
   if [ ! -L 'sfall' ] && [ ! -d 'sfall' ]; then
-    # ln -s "$MODDERPACK_DIR/scripting_docs/headers" sfall
-    echo "== Creating symlink to modderspack headers =="
-    ln -s ../../modderspack/scripting_docs/headers sfall
+
+    # echo "== Creating relative symlink to modderspack headers =="
+    # ln -s ../../modderspack/scripting_docs/headers sfall
+
+    echo "== Creating absolute symlink to modderspack headers =="
+    ln -s "$MODDERPACK_DIR/scripting_docs/headers" sfall
   else
     echo "== Symlink to modderspack headers already exists =="
   fi


### PR DESCRIPTION
This PR changes build mode from `NODEFS` into `NODERAWFS`. It allows to mount host filesystem into guest root.

Previously we mounted host into `/host` folder. Everything works expect absolute symlinks - they were pointing to the path inside host filesystem, i.e. without `/host` prefix. This caused compilation to fail if absolute symlinks were used.

`NODERAWFS` still causes problems if the Module runs multiple times from the same process. To avoid this a VSCode extension spawns a separate process each time, similar to calling `compile.exe` directly.

